### PR TITLE
Fixed a conflict with Compressor configuration. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ MIDDLEWARE = [
     # ...
 ]
 ```   
-6. Create two new folders and an `input.css` file inside the `static/src/` folder:
+7. Create two new folders and an `input.css` file inside the `static/src/` folder:
 
 ```bash
 static
@@ -95,7 +95,7 @@ static
 
 Later we will import the Tailwind CSS directives and use it as the source file for the final stylesheet.
 
-7. Create a new `views.py` file inside `flowbiteapp/` next to `urls.py` and add the following content:
+8. Create a new `views.py` file inside `flowbiteapp/` next to `urls.py` and add the following content:
 
 ```bash
 from django.shortcuts import render
@@ -104,7 +104,7 @@ def index(request):
     return render(request, 'index.html')
 ```
 
-8. Import the newly created view instance inside the `urls.py` file by adding the following code:
+9. Import the newly created view instance inside the `urls.py` file by adding the following code:
 
 ```bash
 from .views import index
@@ -115,7 +115,7 @@ urlpatterns = [
 ]
 ```
 
-9. Create a new `_base.html` file inside the `templates/` directory:
+10. Create a new `_base.html` file inside the `templates/` directory:
 
 ```html
 <!-- templates/_base.html -->
@@ -148,7 +148,7 @@ urlpatterns = [
 </html>
 ```
 
-10. Create an `index.html` file that will be served as the homepage:
+11. Create an `index.html` file that will be served as the homepage:
 
 ```html
 <!-- templates/index.html -->
@@ -160,7 +160,7 @@ urlpatterns = [
 {% endblock content %}
 ```
 
-11. Finally, create a local server instance by running the following command:
+12. Finally, create a local server instance by running the following command:
 
 ```bash
 python manage.py runserver

--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@ TEMPLATES = [
 ]
 ```
 
-3. Installed `django-compressor` by running the following command in your terminal:
+3. Install `django-compressor` and `django-browser-reload` by running the following commands in your terminal:
 
 ```bash
 python -m pip install django-compressor
 ```
+```bash
+python -m pip install django-browser-reload
+```
 
-4. Add `compressor` and `flowbiteapp` (or the name of your app) to the installed apps inside the `settings.py` file:
+4. Add `compressor`,`django_browser_reload` and `flowbiteapp` (or the name of your app) to the installed apps inside the `settings.py` file:
 
 ```bash
 # config/settings.py
@@ -57,6 +60,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'compressor',  # new
     'flowbiteapp',  # new
+    'django_browser_reload' #new
 ]
 ```
 
@@ -67,9 +71,20 @@ COMPRESS_ROOT = BASE_DIR / 'static'
 
 COMPRESS_ENABLED = True
 
-STATICFILES_FINDERS = ('compressor.finders.CompressorFinder',)
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+]
 ```
-
+6. Add the Middleware in the `settings.py`:
+```bash
+MIDDLEWARE = [
+    # ...
+    "django_browser_reload.middleware.BrowserReloadMiddleware",
+    # ...
+]
+```   
 6. Create two new folders and an `input.css` file inside the `static/src/` folder:
 
 ```bash

--- a/flowbiteapp/settings.py
+++ b/flowbiteapp/settings.py
@@ -38,7 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'compressor',
-    'flowbiteapp'
+    'flowbiteapp',
+    'django_browser_reload',
 ]
 
 MIDDLEWARE = [
@@ -49,6 +50,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_browser_reload.middleware.BrowserReloadMiddleware',
 ]
 
 ROOT_URLCONF = 'flowbiteapp.urls'
@@ -128,4 +130,9 @@ COMPRESS_ROOT = BASE_DIR / 'static'
 
 COMPRESS_ENABLED = True
 
-STATICFILES_FINDERS = ('compressor.finders.CompressorFinder',)
+#STATICFILES_FINDERS = ('compressor.finders.CompressorFinder',) 
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+]

--- a/flowbiteapp/urls.py
+++ b/flowbiteapp/urls.py
@@ -15,11 +15,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from .views import index, accordion, carousel, collapse, dial, dismiss, modal, drawer, dropdown, popover, tabs, tooltip, input_counter, datepicker
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path("__reload__/", include("django_browser_reload.urls")),
     path('', index, name='index'),
     path('accordion', accordion, name='accordion'),
     path('carousel', carousel, name='carousel'),


### PR DESCRIPTION
I used **Flowbite** recently in my project and used the **browser reload package** for automatic reloads on the browser. I achieved the automatic browser reload but when I got to the admin panel the styles were broken as the image below.


![Django-admin with CSS Broken](https://github.com/user-attachments/assets/be5d8049-c333-4c6b-af5b-3bfd1aca6840)


After researching on the  issue I managed to fix the bug with extra configurations in the **settings.py** and was able to restore the Admin UI as shown below and went ahead to install jazzmin to customize my admin panel. 


![Django-admin with CSS restored after adding the settings](https://github.com/user-attachments/assets/13e65cc0-8a8b-4fd4-9d7e-40bbb570bcdd)


The issue is likely caused by the compressor configuration overriding the default static files finders. The solution above should restore the proper admin interface styling while maintaining your compressor functionality for other static files.
I made it my intention to come up with this new documentation for anyone who may come across a similar issue. 